### PR TITLE
- Added a reference to Ethair Balloons library

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Key enhancements over go-ethereum:
 
 [<img src="https://raw.githubusercontent.com/petrosDemetrakopoulos/ethairballoons/master/logo_official.png" align="right" width="100">](https://github.com/petrosDemetrakopoulos/ethairballoons) 
 ### [EthAir Balloons](https://github.com/petrosDemetrakopoulos/ethairballoons)
-- A strictly typed ORM library for Ethereum blockchain. It allows you to use Ethereum blockchain as a persistent storage in an organized and model-oriented way without writing custom complex Smart contracts.
+- A strictly typed ORM library for Ethereum blockchain. It allows developers to use Ethereum blockchain as a persistent storage in an organized and model-oriented way without writing custom complex Smart contracts.
 
 ---
 ## Further Extension

--- a/README.md
+++ b/README.md
@@ -526,8 +526,8 @@ Key enhancements over go-ethereum:
 ### ArcBlock
 - [Blockchain Developer Platform](https://www.arcblock.io) / [White Paper](https://www.arcblock.io/en/whitepaper/latest)
 
-[<img src="https://raw.githubusercontent.com/petrosDemetrakopoulos/ethairballoons/master/logo_official.png" align="right" width="100">](https://github.com/petrosDemetrakopoulos/ethairballoons))  
-### [**EthAir Balloons**](https://github.com/petrosDemetrakopoulos/ethairballoons)
+[<img src="https://raw.githubusercontent.com/petrosDemetrakopoulos/ethairballoons/master/logo_official.png" align="right" width="100">](https://github.com/petrosDemetrakopoulos/ethairballoons) 
+### [EthAir Balloons](https://github.com/petrosDemetrakopoulos/ethairballoons)
 - A strictly typed ORM library for Ethereum blockchain. It allows you to use Ethereum blockchain as a persistent storage in an organized and model-oriented way without writing custom complex Smart contracts.
 
 ---

--- a/README.md
+++ b/README.md
@@ -526,6 +526,10 @@ Key enhancements over go-ethereum:
 ### ArcBlock
 - [Blockchain Developer Platform](https://www.arcblock.io) / [White Paper](https://www.arcblock.io/en/whitepaper/latest)
 
+[<img src="https://raw.githubusercontent.com/petrosDemetrakopoulos/ethairballoons/master/logo_official.png" align="right" width="100">](https://github.com/petrosDemetrakopoulos/ethairballoons))  
+### [**EthAir Balloons**](https://github.com/petrosDemetrakopoulos/ethairballoons)
+- A strictly typed ORM library for Ethereum blockchain. It allows you to use Ethereum blockchain as a persistent storage in an organized and model-oriented way without writing custom complex Smart contracts.
+
 ---
 ## Further Extension
 ### [Papers](https://github.com/decrypto-org/blockchain-papers)


### PR DESCRIPTION
In the "Projects and Applications" section, I added a reference to [Ethair balloons](https://github.com/petrosDemetrakopoulos/ethairballoons). A strictly typed ORM library for Ethereum blockchain. It allows developers to use Ethereum blockchain as a persistent storage in an organized and model-oriented way without writing custom complex Smart contracts. The library is available for installation through the npm package manager.