### PR TITLE
Add BTCBench Fee Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,7 @@ Key enhancements over go-ethereum:
     +   [Zapper](https://zapper.fi/): dashboard for viewing and managing your DeFi investments.
     +   [Furucombo](https://furucombo.app/): easily create flashloans without writing a single line of code.
     +   [Covalent](https://www.covalenthq.com/): an unified API bringing visibility to billions of blockchain data points.
+    +   [BTCBench Fee Calculator](https://www.btcbench.com/calculator.html) - Estimate transaction costs based on current network conditions.
 
 ### Roadmaps
 


### PR DESCRIPTION
Hi,

I'd like to add Bitcoin Fee Calculator to the  DeFi (Decentralized Finance) section.

**About:**
- Free tool to estimate Bitcoin transaction fees (real-time)
- Based on current network conditions
- No signup required

Website: https://www.btcbench.com/calculator.html

Thank you for maintaining this awesome-blockchain list!