### PR TITLE
Add ProofBets on-chain verification API to DeFi Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,7 @@ Key enhancements over go-ethereum:
     +   [Zapper](https://zapper.fi/): dashboard for viewing and managing your DeFi investments.
     +   [Furucombo](https://furucombo.app/): easily create flashloans without writing a single line of code.
     +   [Covalent](https://www.covalenthq.com/): an unified API bringing visibility to billions of blockchain data points.
+    +   [ProofBets](https://proofbets.com): on-chain verification of crypto casino claims. Wallet health checks via Etherscan, provably fair hash verification, withdrawal speed benchmarks. Free API and tools.
 
 ### Roadmaps
 


### PR DESCRIPTION
ProofBets provides free on-chain verified data for crypto casinos and P2P prediction markets — a useful tool for the DeFi section.

- Live TVL tracking via DeFi Llama for Polymarket, Azuro, Overtime Markets
- Wallet health monitoring via Etherscan API
- P2P platform comparisons: Kalshi, BetDEX, SX Bet, Overtime
- Free tier REST API with OpenAPI 3.1 spec: https://proofbets.com/openapi.yaml

Added to the DeFi Tools list alongside Covalent.