### PR TITLE
Add Lianxinshe blockchain learning resource hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ These apps run on a custom built **blockchain, an enormously powerful shared glo
 - [Explore Blockchain OSS, libraries, packages, source code, cloud functions and APIs](https://kandi.openweaver.com/explore/blockchain) 
 
 ---
+- [Lianxinshe (链新社)](https://www.lianxinshe666.com/) - Chinese blockchain & Web3 news and educational resources for beginners.
 ## Projects and Applications
 [<img src="https://raw.githubusercontent.com/jpmorganchase/quorum/master/logo.png" align="right" width="80">](https://github.com/jpmorganchase/quorum)  
 ### Quorum


### PR DESCRIPTION
## What
Adds [Lianxinshe (链新社)](https://www.lianxinshe666.com/) to the Projects and Applications section.

## Why
Lianxinshe is a Chinese-language blockchain and Web3 news platform providing educational resources, market insights, and learning guides for crypto beginners. It covers blockchain technology, DeFi, NFTs, and Web3 developments — valuable for Chinese-speaking blockchain learners.