### PR TITLE
Add DeepAlpha to DeFi Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,7 @@ Key enhancements over go-ethereum:
     +   [Zapper](https://zapper.fi/): dashboard for viewing and managing your DeFi investments.
     +   [Furucombo](https://furucombo.app/): easily create flashloans without writing a single line of code.
     +   [Covalent](https://www.covalenthq.com/): an unified API bringing visibility to billions of blockchain data points.
+    +   [DeepAlpha](https://github.com/stefanoviana/deepalpha): AI-powered crypto trading bot with ML ensemble, 12 exchanges, grid trading, and DCA strategies.
 
 ### Roadmaps
 


### PR DESCRIPTION
## Description

Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the DeFi Tools section.

**DeepAlpha** is an open-source AI crypto trading bot featuring:
- 3-model ML ensemble (XGBoost, LightGBM, CatBoost)
- 12 exchanges supported via CCXT
- Grid trading, DCA with safety orders
- Walk-forward validated

Fits well alongside other DeFi tools like Defi Dashboard and Zapper.

Thank you for maintaining this awesome list!