### PR TITLE
Add RustChain to Implementation of Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,8 @@ These apps run on a custom built **blockchain, an enormously powerful shared glo
     -   [_Transaction relaying_](https://lhartikk.github.io/jekyll/update/2017/07/10/chapter5.html)
     -   [_Wallet UI and blockchain explorer_](https://lhartikk.github.io/jekyll/update/2017/07/09/chapter6.html)
 -   [**TypeScript**: _NaivecoinStake: a tutorial for building a cryptocurrency with the Proof of Stake consensus_](https://naivecoinstake.learn.uno/)
-- [Explore Blockchain OSS, libraries, packages, source code, cloud functions and APIs](https://kandi.openweaver.com/explore/blockchain) 
+-   [**Rust**: _RustChain - Proof-of-Antiquity blockchain that rewards vintage hardware_](https://github.com/Scottcjn/Rustchain) - A Rust+Python hybrid chain where old computers earn more than new ones, supporting 15+ CPU architectures.
+- [Explore Blockchain OSS, libraries, packages, source code, cloud functions and APIs](https://kandi.openweaver.com/explore/blockchain)
 
 ---
 ## Projects and Applications


### PR DESCRIPTION
Hi! I'd like to add [RustChain](https://github.com/Scottcjn/Rustchain) to the Implementation of Blockchain section.

RustChain is a Proof-of-Antiquity blockchain built with Rust+Python that rewards vintage hardware. Old computers earn more than new ones. It supports 15+ CPU architectures including PowerPC, SPARC, MIPS, ARM, and x86.

Thanks for maintaining this awesome list!